### PR TITLE
MIN: Update links/references to Spyder to point to new website, and minor opportunistic cleanup

### DIFF
--- a/source/gettingstarted.rst
+++ b/source/gettingstarted.rst
@@ -6,7 +6,7 @@ Getting Started
 Installation
 ------------
 
-In order to run :math:`\omega radlib`, you need to have a Python interpreter installed on your local computer, as well as a number of Python packages (`Dependencies`_). We recommend to install `Anaconda <https://www.anaconda.com/what-is-anaconda/>`_ as it installs Python, a number of required packages, and other useful tools (e.g. spyder).
+In order to run :math:`\omega radlib`, you need to have a Python interpreter installed on your local computer, as well as a number of Python packages (`Dependencies`_). We recommend installing `Anaconda <https://www.anaconda.com/what-is-anaconda/>`_ as it includes Python, numerous required packages, and other useful tools (e.g. `Spyder <https://www.spyder-ide.org/>`_).
 
 Using Anaconda the installation process is harmonised across platforms. Download and install the latest Anaconda distribution from https://www.anaconda.com/download/ for your specific OS. You might also consider the minimal `Miniconda <https://conda.io/miniconda.html>`_ if you do not want to install a full scientific python stack.
 
@@ -145,8 +145,8 @@ You can check whether the required `Dependencies`_ are available on your compute
 
 >>> import <package_name>
 ImportError: No module named <package_name>
- 
-This will be the response in case the package is not available. 
+
+This will be the response in case the package is not available.
 
 In case the import is successful, you should also check the version number:
 

--- a/source/ide.rst
+++ b/source/ide.rst
@@ -4,7 +4,7 @@ Integrated Development Environments for Python
 Development Environments vs. Notebooks
 --------------------------------------
 
-Jupyter notebooks are great for courses and for interactive data exploration. However, they are not suited for developing applications. Once you start to build applications or scripts on top of :math:`\omega radlib`, you should use a suitable Integrated Development Environmemt (IDE). IDEs give you the opportunity for organising different source files, debugging, avraible inspection and a lot more.
+Jupyter notebooks are great for courses and for interactive data exploration. However, they are not suited for developing applications. Once you start to build applications or scripts on top of :math:`\omega radlib`, you should use a suitable Integrated Development Environment (IDE). IDEs give you the opportunity for organising different source files, debugging, available inspection and a lot more.
 
 
 Some suitable IDEs
@@ -12,8 +12,8 @@ Some suitable IDEs
 
 There is a `comprehensive Wiki article on Python IDEs <https://wiki.python.org/moin/IntegratedDevelopmentEnvironments>`_. Maybe a bit too comprehensive... if you already are used to an IDE and happy with it, there is no reason to change it.
 
-However, if you have no idea which IDE to choose, why not start with `Spyder <https://pythonhosted.org/spyder/>`_. It is included in the `Anaconda Python Distribution <https://www.anaconda.com/download/>`_ by default. If you installed Anaconda, just open a shell and enter::
+However, if you have no idea which IDE to choose, why not start with `Spyder <https://www.spyder-ide.org/>`_? It is included in the `Anaconda Python Distribution <https://www.anaconda.com/download/>`_ by default. If you installed Anaconda, just open a shell (Anaconda Prompt on Windows) and enter::
 
-	$ spyder
-	
+    $ spyder
+
 Alternatively, we can warmly recommend `PyCharm <https://www.jetbrains.com/pycharm/>`_ which has a free, yet powerful `Community Edition <https://www.jetbrains.com/pycharm/features/>`_.


### PR DESCRIPTION
Hey, I'm a member of the Spyder IDE core dev team (as well as a MS grad student in atmospheric sciences at UAH), and we're really happy you have such nice things to say about the IDE! Per spyder-ide/spyder-docs#39, we've been updating references to Spyder's ancient, un(able to be )maintained PyPI/PythonHosted docs (which will soon be finally removed, so as to prevent the user confusion that has resulted) to point to our modern website, with our new docs as well as information and updates about Spyder.

I happened to come across this project when looking for modern alternatives to solo3 (which was listed as "legacy" by NCAR but had no stated direct replacement), and noticed the mention of Spyder with the old link so I figured I'd update it (as well as do some grammar fixes and cleanup in the lines I'd already touched while I was at it).

Also, somewhat OT but I couldn't find it anywhere in documentation—how does this project compare to the more popular ``PyART``, given they are both Python packages with outwardly similar goals—i.e. why might I use ``wradlib`` over ``PyART``, and what is the rationale for actively maintaining two separate projects? Thanks!