### PR TITLE
MIN: use pip instead of conda in rtd build

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,8 @@
-conda:
-  file: readthedocs_environment.yml
+build:
+    image: latest
+
+python:
+    version: 3.6
+    use_system_site_packages: true
+
+requirements_file: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+sphinx>=1.4
+nbconvert
+ipykernel
+sphinx_rtd_theme
+sphinxcontrib-bibtex
+deprecation
+nbsphinx
+xmltodict


### PR DESCRIPTION
closes #7 